### PR TITLE
ci(destroy): add workflow_dispatch and terragrunt retry on all commands

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -2,6 +2,12 @@ name: Destroy PR environment
 on:
   pull_request_target:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number whose pr-<N> stage to destroy in dev + prod'
+        required: true
+        type: string
 
 env:
   TG_NON_INTERACTIVE: 'true'
@@ -15,7 +21,7 @@ jobs:
         environment: ['dev', 'prod']
     env:
       ENVIRONMENT: ${{ matrix.environment }}
-      TF_VAR_stage: pr-${{ github.event.number }}
+      TF_VAR_stage: pr-${{ github.event.inputs.pr_number || github.event.number }}
       TF_VAR_dist_dir: ${{ github.workspace }}/dist
       TF_VAR_migrations_dir: ${{ github.workspace }}/apps/version/migrations
       OP_SERVICE_ACCOUNT_TOKEN: ${{ matrix.environment == 'prod' && secrets.OP_TF_PROD_ENV || secrets.OP_TF_DEV_ENV }}

--- a/deployment/state.hcl
+++ b/deployment/state.hcl
@@ -10,6 +10,14 @@ remote_state {
   }
 }
 
+errors {
+  retry "transient" {
+    retryable_errors   = [".*"]
+    max_attempts       = 3
+    sleep_interval_sec = 30
+  }
+}
+
 inputs = {
   tf_state_postgres_conn_str = local.tf_state_postgres_conn_str
 }


### PR DESCRIPTION
- workflow_dispatch input lets us manually re-run destroy for orphaned pr-N stages when the original pull_request_target run failed against a broken workflow file (re-runs replay the old workflow version)
- errors { retry } in state.hcl retries any terragrunt command (apply, destroy, plan) up to 3x with 30s backoff on any error, covering transient provider/network flakes without re-running successful modules