### PR TITLE
feat: split version worker dashboard into ops and server analytics

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -4,6 +4,9 @@ terragrunt = "1.1.0"
 
 [env]
 TF_VAR_dist_dir="{{config_root}}/dist"
+# op vault references in deployment/.env only resolve in the immich account;
+# without this, op defaults to whichever signed-in account was used last
+OP_ACCOUNT="immich.1password.com"
 
 [tasks.tg]
 run = "op run '--env-file={{config_root}}/deployment/.env' -- terragrunt"

--- a/deployment/modules/cloudflare/workers/version/dashboards/version-worker-overview.json
+++ b/deployment/modules/cloudflare/workers/version/dashboards/version-worker-overview.json
@@ -387,13 +387,13 @@
           "expr": "quantile(0.95, last_over_time(version_handle_request_duration[$__interval]))",
           "legendFormat": "handle_request p95",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "quantile(0.95, last_over_time(version_version_request_duration[$__interval]))",
           "legendFormat": "/version p95",
           "refId": "B",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "Request Duration (p95)",
@@ -562,31 +562,31 @@
           "expr": "sum(count_over_time(version_changelog_request_invocation{cache=\"cdn\"}[$__interval]))",
           "legendFormat": "CDN hit (/changelog)",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_changelog_request_invocation{cache=\"\"}[$__interval]))",
           "legendFormat": "CDN miss (/changelog)",
           "refId": "B",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_memory_cache_hit_count[$__interval]))",
           "legendFormat": "memory hit (/version)",
           "refId": "C",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_memory_cache_stale_count[$__interval]))",
           "legendFormat": "memory stale (/version)",
           "refId": "D",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_memory_cache_miss_count[$__interval]))",
           "legendFormat": "memory miss (/version)",
           "refId": "E",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "Cache Hit Rate",
@@ -678,7 +678,7 @@
           "expr": "sum(count_over_time(version_handle_request_invocation[$__interval])) by (continent)",
           "legendFormat": "{{continent}}",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "Requests by Region",
@@ -784,31 +784,31 @@
           "expr": "quantile(0.95, last_over_time(version_d1_get_latest_duration[$__interval]))",
           "legendFormat": "get_latest p95",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "quantile(0.95, last_over_time(version_d1_get_changelog_duration[$__interval]))",
           "legendFormat": "get_changelog p95",
           "refId": "B",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "quantile(0.95, last_over_time(version_d1_upsert_duration[$__interval]))",
           "legendFormat": "upsert p95",
           "refId": "C",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "quantile(0.95, last_over_time(version_d1_bulk_upsert_duration[$__interval]))",
           "legendFormat": "bulk_upsert p95",
           "refId": "D",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "quantile(0.95, last_over_time(version_webhook_upsert_duration[$__interval]))",
           "legendFormat": "webhook_upsert p95",
           "refId": "E",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "D1 Query Duration (p95)",
@@ -899,25 +899,25 @@
           "expr": "sum(count_over_time(version_d1_get_latest_invocation[$__interval]))",
           "legendFormat": "get_latest",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_d1_get_changelog_invocation[$__interval]))",
           "legendFormat": "get_changelog",
           "refId": "B",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_d1_upsert_invocation[$__interval]))",
           "legendFormat": "upsert",
           "refId": "C",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_d1_bulk_upsert_invocation[$__interval]))",
           "legendFormat": "bulk_upsert",
           "refId": "D",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "D1 Query Rate",
@@ -1007,25 +1007,25 @@
           "expr": "sum(count_over_time(version_d1_get_latest_errors[$__interval])) or vector(0)",
           "legendFormat": "get_latest errors",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_d1_get_changelog_errors[$__interval])) or vector(0)",
           "legendFormat": "get_changelog errors",
           "refId": "B",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_d1_upsert_errors[$__interval])) or vector(0)",
           "legendFormat": "upsert errors",
           "refId": "C",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_d1_bulk_upsert_errors[$__interval])) or vector(0)",
           "legendFormat": "bulk_upsert errors",
           "refId": "D",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "D1 Error Rate",
@@ -1117,7 +1117,7 @@
           "expr": "max(last_over_time(version_d1_release_count_count[$__interval]))",
           "legendFormat": "releases",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "Releases Stored Over Time",
@@ -1221,13 +1221,13 @@
           "expr": "sum(count_over_time(version_webhook_received_count[$__interval])) by (event)",
           "legendFormat": "received ({{event}})",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_webhook_release_upserted_count[$__interval]))",
           "legendFormat": "upserted",
           "refId": "B",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "Webhook Events",
@@ -1318,25 +1318,25 @@
           "expr": "sum(count_over_time(version_cron_sync_invocation[$__interval]))",
           "legendFormat": "cron runs",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(sum_over_time(version_cron_releases_synced_count[$__interval]))",
           "legendFormat": "releases synced",
           "refId": "B",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(count_over_time(version_cron_release_updated_count[$__interval]))",
           "legendFormat": "releases updated",
           "refId": "C",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "sum(sum_over_time(version_cron_full_sync_count[$__interval]))",
           "legendFormat": "nightly full sync",
           "refId": "D",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "Cron Sync",
@@ -1429,13 +1429,13 @@
           "expr": "quantile(0.95, last_over_time(version_github_fetch_latest_duration[$__interval]))",
           "legendFormat": "fetch latest p95",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         },
         {
           "expr": "quantile(0.95, last_over_time(version_github_fetch_all_duration[$__interval]))",
           "legendFormat": "fetch all p95",
           "refId": "B",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "GitHub API Duration",
@@ -1625,7 +1625,7 @@
           "expr": "sum(count_over_time(version_http_response_count{method!=\"POST\"}[$__interval])) by (path)",
           "legendFormat": "{{path}}",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "Requests by Path (non-POST)",
@@ -1762,7 +1762,7 @@
           "expr": "sum(count_over_time(version_http_response_count[$__interval])) by (status)",
           "legendFormat": "{{status}}",
           "refId": "A",
-          "interval": "1m"
+          "interval": "5m"
         }
       ],
       "title": "Response Status Codes",
@@ -1795,6 +1795,6 @@
   "timezone": "browser",
   "title": "Version Worker Overview",
   "uid": "version-worker-overview",
-  "version": 8,
+  "version": 9,
   "weekStart": ""
 }

--- a/deployment/modules/cloudflare/workers/version/dashboards/version-worker-overview.json
+++ b/deployment/modules/cloudflare/workers/version/dashboards/version-worker-overview.json
@@ -38,69 +38,6 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.3",
-      "targets": [
-        {
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h])))",
-          "refId": "A",
-          "instant": true,
-          "range": false,
-          "interval": "5m"
-        }
-      ],
-      "title": "Unique Servers (24h)",
-      "type": "stat",
-      "maxDataPoints": 300
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
                 "color": "blue",
                 "value": null
               }
@@ -112,8 +49,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 4,
+        "w": 6,
+        "x": 0,
         "y": 0
       },
       "id": 2,
@@ -184,8 +121,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 8,
+        "w": 6,
+        "x": 6,
         "y": 0
       },
       "id": 3,
@@ -228,79 +165,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 1,
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "noValue": "-",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0.5
-              },
-              {
-                "color": "green",
-                "value": 0.8
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 12,
-        "y": 0
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.3",
-      "targets": [
-        {
-          "expr": "count(count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h])) and on(user_agent) last_over_time(version_latest_version_count[3h])) / count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h])))",
-          "refId": "A",
-          "instant": true,
-          "range": false,
-          "interval": "5m"
-        }
-      ],
-      "title": "Servers Up-to-date (24h)",
-      "type": "stat",
-      "maxDataPoints": 300
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
           "decimals": 0,
           "mappings": [],
           "noValue": "-",
@@ -319,8 +183,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 16,
+        "w": 6,
+        "x": 12,
         "y": 0
       },
       "id": 5,
@@ -389,8 +253,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 20,
+        "w": 6,
+        "x": 18,
         "y": 0
       },
       "id": 6,
@@ -431,861 +295,6 @@
         "x": 0,
         "y": 4
       },
-      "id": 7,
-      "panels": [],
-      "title": "Immich Servers",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 5
-      },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-          },
-          "editorMode": "code",
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[2h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[2h])))",
-          "legendFormat": "unique servers (2h)",
-          "range": true,
-          "refId": "A",
-          "interval": "5m"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-          },
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h])))",
-          "legendFormat": "unique servers (24h)",
-          "refId": "B",
-          "interval": "5m"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-          },
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d])))",
-          "legendFormat": "unique servers (30d)",
-          "refId": "C",
-          "interval": "5m"
-        }
-      ],
-      "title": "Unique Servers Over Time",
-      "type": "timeseries",
-      "maxDataPoints": 300
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 5
-      },
-      "id": 9,
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value",
-            "percent"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "expr": "label_replace(count(count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h]))) by (user_agent), \"version\", \"$1\", \"user_agent\", \"immich-server/(.*)\")",
-          "legendFormat": "{{version}}",
-          "refId": "A",
-          "instant": true,
-          "range": false,
-          "interval": "5m"
-        }
-      ],
-      "title": "Version Distribution (24h)",
-      "type": "piechart",
-      "maxDataPoints": 300
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 30,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "percent"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 13
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-          },
-          "editorMode": "code",
-          "expr": "label_replace(count(count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[2h]))) by (user_agent), \"version\", \"$1\", \"user_agent\", \"immich-server/(.*)\")",
-          "legendFormat": "{{version}}",
-          "range": true,
-          "refId": "A",
-          "interval": "5m"
-        }
-      ],
-      "title": "Version Adoption Over Time",
-      "type": "timeseries",
-      "maxDataPoints": 300
-    },
-    {
-      "title": "Latest Version: Upgrades vs New Installs",
-      "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 21
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "targets": [
-        {
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1h]) and on(user_agent) last_over_time(version_latest_version_count[3h])) and count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h)))",
-          "legendFormat": "upgrades (seen before)",
-          "refId": "A",
-          "interval": "5m"
-        },
-        {
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1h]) and on(user_agent) last_over_time(version_latest_version_count[3h])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h)))",
-          "legendFormat": "new installs",
-          "refId": "B",
-          "interval": "5m"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 30,
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "axisSoftMin": 0,
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            }
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "upgrades (seen before)"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "new installs"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "maxDataPoints": 300
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 50,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 13
-      },
-      "id": 11,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[5m]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[5m])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 5m) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 5m)))",
-          "legendFormat": "new servers",
-          "refId": "A",
-          "interval": "5m"
-        }
-      ],
-      "title": "New Servers (not seen in last 30d)",
-      "type": "timeseries",
-      "maxDataPoints": 300
-    },
-    {
-      "title": "New Server Rate",
-      "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 29
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "targets": [
-        {
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[1h])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h)))",
-          "legendFormat": "new servers / 1h",
-          "refId": "A",
-          "interval": "5m"
-        },
-        {
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1d]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[1d])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1d) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1d)))",
-          "legendFormat": "new servers / day",
-          "refId": "B",
-          "interval": "5m",
-          "hide": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "axisSoftMin": 0,
-            "spanNulls": true
-          },
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "maxDataPoints": 300
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 37
-      },
-      "id": 12,
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value",
-            "percent"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "expr": "count(count by (client_ip, continent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h]))) by (continent)",
-          "legendFormat": "{{continent}}",
-          "refId": "A",
-          "instant": true,
-          "range": false,
-          "interval": "5m"
-        }
-      ],
-      "title": "Servers by Continent (24h)",
-      "type": "piechart",
-      "maxDataPoints": 300
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Immich servers"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Other"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 6,
-        "y": 37
-      },
-      "id": 13,
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value",
-            "percent"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "expr": "(sum(count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h])) or vector(0)) + (sum(count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h])) or vector(0))",
-          "legendFormat": "Immich servers",
-          "refId": "A",
-          "instant": true,
-          "range": false
-        },
-        {
-          "expr": "(sum(count_over_time(version_version_request_invocation{user_agent!~\"immich-server/.*\",user_agent!=\"\"}[24h])) or vector(0)) + (sum(count_over_time(version_changelog_request_invocation{user_agent!~\"immich-server/.*\",user_agent!=\"\"}[24h])) or vector(0))",
-          "legendFormat": "Other",
-          "refId": "B",
-          "instant": true,
-          "range": false
-        }
-      ],
-      "title": "Traffic Source (24h)",
-      "type": "piechart",
-      "maxDataPoints": 300
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-blues"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 12,
-        "y": 37
-      },
-      "id": 14,
-      "options": {
-        "displayMode": "gradient",
-        "maxVizHeight": 300,
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "namePlacement": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
-      },
-      "pluginVersion": "10.4.3",
-      "targets": [
-        {
-          "expr": "topk(15, sum(count_over_time(version_handle_request_invocation{colo!=\"\"}[24h])) by (colo))",
-          "legendFormat": "{{colo}}",
-          "refId": "A",
-          "instant": true,
-          "range": false
-        }
-      ],
-      "title": "Top Cloudflare Edge Locations (24h)",
-      "type": "bargauge",
-      "maxDataPoints": 300
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "IPv4"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "IPv6"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 37
-      },
-      "id": 32,
-      "maxDataPoints": 300,
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value",
-            "percent"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{client_ip!~\".*:.*\",client_ip!=\"\"}[24h]) or count_over_time(version_changelog_request_invocation{client_ip!~\".*:.*\",client_ip!=\"\"}[24h])))",
-          "legendFormat": "IPv4",
-          "refId": "A",
-          "instant": true,
-          "range": false
-        },
-        {
-          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{client_ip=~\".*:.*\"}[24h]) or count_over_time(version_changelog_request_invocation{client_ip=~\".*:.*\"}[24h])))",
-          "legendFormat": "IPv6",
-          "refId": "B",
-          "instant": true,
-          "range": false
-        }
-      ],
-      "title": "IPv4 vs IPv6 (24h)",
-      "type": "piechart"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 45
-      },
       "id": 15,
       "panels": [],
       "title": "Worker Performance",
@@ -1296,6 +305,7 @@
         "type": "prometheus",
         "uid": "36979063-5384-4eb9-8679-565a727cbc13"
       },
+      "description": "p95 across active label combinations (per-series), not per request. Cloudflare Workers freezes performance.now() during CPU work, so durations measure I/O wait only.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1357,7 +367,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 46
+        "y": 5
       },
       "id": 16,
       "options": {
@@ -1395,6 +405,7 @@
         "type": "prometheus",
         "uid": "36979063-5384-4eb9-8679-565a727cbc13"
       },
+      "description": "CDN miss = origin-served /changelog requests (no cache tag is emitted on misses; cache=\"\" matches series without the label). The cache=miss selector used before matched nothing.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1531,7 +542,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 46
+        "y": 5
       },
       "id": 17,
       "options": {
@@ -1554,7 +565,7 @@
           "interval": "1m"
         },
         {
-          "expr": "sum(count_over_time(version_changelog_request_invocation{cache=\"miss\"}[$__interval]))",
+          "expr": "sum(count_over_time(version_changelog_request_invocation{cache=\"\"}[$__interval]))",
           "legendFormat": "CDN miss (/changelog)",
           "refId": "B",
           "interval": "1m"
@@ -1647,7 +658,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 13
       },
       "id": 18,
       "options": {
@@ -1680,7 +691,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 21
       },
       "id": 19,
       "panels": [],
@@ -1692,6 +703,7 @@
         "type": "prometheus",
         "uid": "36979063-5384-4eb9-8679-565a727cbc13"
       },
+      "description": "p95 across active label combinations (per-series), not per request. Cloudflare Workers freezes performance.now() during CPU work, so durations measure I/O wait only.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1752,7 +764,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 63
+        "y": 22
       },
       "id": 20,
       "options": {
@@ -1867,7 +879,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 63
+        "y": 22
       },
       "id": 21,
       "options": {
@@ -1975,7 +987,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 71
+        "y": 30
       },
       "id": 22,
       "options": {
@@ -2085,7 +1097,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 71
+        "y": 30
       },
       "id": 23,
       "options": {
@@ -2118,7 +1130,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 79
+        "y": 38
       },
       "id": 24,
       "panels": [],
@@ -2189,7 +1201,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 80
+        "y": 39
       },
       "id": 25,
       "options": {
@@ -2286,7 +1298,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 80
+        "y": 39
       },
       "id": 26,
       "options": {
@@ -2336,6 +1348,7 @@
         "type": "prometheus",
         "uid": "36979063-5384-4eb9-8679-565a727cbc13"
       },
+      "description": "p95 across active label combinations (per-series), not per request. Cloudflare Workers freezes performance.now() during CPU work, so durations measure I/O wait only.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2396,7 +1409,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 88
+        "y": 47
       },
       "id": 27,
       "options": {
@@ -2455,7 +1468,7 @@
         "h": 8,
         "w": 8,
         "x": 12,
-        "y": 88
+        "y": 47
       },
       "id": 28,
       "options": {
@@ -2521,7 +1534,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 96
+        "y": 55
       },
       "id": 29,
       "panels": [],
@@ -2592,7 +1605,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 97
+        "y": 56
       },
       "id": 30,
       "options": {
@@ -2729,7 +1742,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 97
+        "y": 56
       },
       "id": 31,
       "options": {
@@ -2757,7 +1770,7 @@
       "maxDataPoints": 300
     }
   ],
-  "refresh": "30s",
+  "refresh": "1m",
   "schemaVersion": 39,
   "tags": [
     "cloudflare-workers",
@@ -2770,10 +1783,18 @@
     "from": "now-6h",
     "to": "now"
   },
-  "timepicker": {},
+  "timepicker": {
+    "refresh_intervals": [
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h"
+    ]
+  },
   "timezone": "browser",
   "title": "Version Worker Overview",
   "uid": "version-worker-overview",
-  "version": 7,
+  "version": 8,
   "weekStart": ""
 }

--- a/deployment/modules/cloudflare/workers/version/dashboards/version-worker-server-analytics.json
+++ b/deployment/modules/cloudflare/workers/version/dashboards/version-worker-server-analytics.json
@@ -1012,6 +1012,665 @@
       ],
       "title": "IPv4 vs IPv6 (24h)",
       "type": "piechart"
+    },
+    {
+      "collapsed": true,
+      "id": 40,
+      "title": "Recording Rule Validation (temporary)",
+      "type": "row",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "description": "Temporary: validates vmalert recording rules against the raw queries before panels are repointed. Remove after ~1 week of clean overlap.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 46
+          },
+          "id": 41,
+          "maxDataPoints": 150,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[2h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[2h])))",
+              "legendFormat": "raw 2h",
+              "refId": "A",
+              "interval": "5m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_unique:2h",
+              "legendFormat": "rule 2h",
+              "refId": "B",
+              "interval": "5m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h])))",
+              "legendFormat": "raw 24h",
+              "refId": "C",
+              "interval": "30m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_unique:24h",
+              "legendFormat": "rule 24h",
+              "refId": "D",
+              "interval": "5m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d])))",
+              "legendFormat": "raw 30d",
+              "refId": "E",
+              "interval": "1h",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_unique:30d",
+              "legendFormat": "rule 30d",
+              "refId": "F",
+              "interval": "30m",
+              "range": true
+            }
+          ],
+          "title": "Unique servers \u2014 raw vs rule",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "description": "Temporary: validates vmalert recording rules against the raw queries before panels are repointed. Remove after ~1 week of clean overlap.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 54
+          },
+          "id": 42,
+          "maxDataPoints": 150,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[5m]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[5m])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 5m) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 5m)))",
+              "legendFormat": "raw 5m",
+              "refId": "A",
+              "interval": "5m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_new:5m",
+              "legendFormat": "rule 5m",
+              "refId": "B",
+              "interval": "5m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[1h])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h)))",
+              "legendFormat": "raw 1h",
+              "refId": "C",
+              "interval": "5m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_new:1h",
+              "legendFormat": "rule 1h",
+              "refId": "D",
+              "interval": "5m",
+              "range": true
+            }
+          ],
+          "title": "New servers \u2014 raw vs rule",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "description": "Temporary: validates vmalert recording rules against the raw queries before panels are repointed. Remove after ~1 week of clean overlap.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 54
+          },
+          "id": 43,
+          "maxDataPoints": 150,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1h]) and on(user_agent) last_over_time(version_latest_version_count[3h])) and count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h)))",
+              "legendFormat": "raw upgrades",
+              "refId": "A",
+              "interval": "5m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_upgrades:1h",
+              "legendFormat": "rule upgrades",
+              "refId": "B",
+              "interval": "5m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1h]) and on(user_agent) last_over_time(version_latest_version_count[3h])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h)))",
+              "legendFormat": "raw new installs",
+              "refId": "C",
+              "interval": "5m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_new_installs:1h",
+              "legendFormat": "rule new installs",
+              "refId": "D",
+              "interval": "5m",
+              "range": true
+            }
+          ],
+          "title": "Upgrades / new installs \u2014 raw vs rule",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "description": "Temporary: validates vmalert recording rules against the raw queries before panels are repointed. Remove after ~1 week of clean overlap.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "percentunit",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 62
+          },
+          "id": 44,
+          "maxDataPoints": 150,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h])) and on(user_agent) last_over_time(version_latest_version_count[3h])) / count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h])))",
+              "legendFormat": "raw",
+              "refId": "A",
+              "interval": "30m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_uptodate_ratio:24h",
+              "legendFormat": "rule",
+              "refId": "B",
+              "interval": "5m",
+              "range": true
+            }
+          ],
+          "title": "Up-to-date ratio \u2014 raw vs rule",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "description": "Temporary: validates vmalert recording rules against the raw queries before panels are repointed. Remove after ~1 week of clean overlap.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 62
+          },
+          "id": 45,
+          "maxDataPoints": 150,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "label_replace(count(count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h]))) by (user_agent), \"version\", \"$1\", \"user_agent\", \"immich-server/(.*)\")",
+              "legendFormat": "raw {{version}}",
+              "refId": "A",
+              "interval": "1h",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "label_replace(version:servers_by_version:24h, \"version\", \"$1\", \"user_agent\", \"immich-server/(.*)\")",
+              "legendFormat": "rule {{version}}",
+              "refId": "B",
+              "interval": "30m",
+              "range": true
+            }
+          ],
+          "title": "Servers by version (24h) \u2014 raw vs rule",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "description": "Temporary: validates vmalert recording rules against the raw queries before panels are repointed. Remove after ~1 week of clean overlap.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 70
+          },
+          "id": 46,
+          "maxDataPoints": 150,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip, continent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h]))) by (continent)",
+              "legendFormat": "raw {{continent}}",
+              "refId": "A",
+              "interval": "1h",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_by_continent:24h",
+              "legendFormat": "rule {{continent}}",
+              "refId": "B",
+              "interval": "30m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{client_ip!~\".*:.*\",client_ip!=\"\"}[24h]) or count_over_time(version_changelog_request_invocation{client_ip!~\".*:.*\",client_ip!=\"\"}[24h])))",
+              "legendFormat": "raw ipv4",
+              "refId": "C",
+              "interval": "1h",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_ipv4:24h",
+              "legendFormat": "rule ipv4",
+              "refId": "D",
+              "interval": "30m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{client_ip=~\".*:.*\"}[24h]) or count_over_time(version_changelog_request_invocation{client_ip=~\".*:.*\"}[24h])))",
+              "legendFormat": "raw ipv6",
+              "refId": "E",
+              "interval": "1h",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "version:servers_ipv6:24h",
+              "legendFormat": "rule ipv6",
+              "refId": "F",
+              "interval": "30m",
+              "range": true
+            }
+          ],
+          "title": "Continent & IP family \u2014 raw vs rule",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "description": "Temporary: validates vmalert recording rules against the raw queries before panels are repointed. Remove after ~1 week of clean overlap.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 70
+          },
+          "id": 47,
+          "maxDataPoints": 150,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "(sum(count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h])) or vector(0)) + (sum(count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h])) or vector(0))",
+              "legendFormat": "raw immich",
+              "refId": "A",
+              "interval": "1h",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "sum(sum_over_time(version:requests_immich:count5m[24h]))",
+              "legendFormat": "rule immich",
+              "refId": "B",
+              "interval": "30m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "(sum(count_over_time(version_version_request_invocation{user_agent!~\"immich-server/.*\",user_agent!=\"\"}[24h])) or vector(0)) + (sum(count_over_time(version_changelog_request_invocation{user_agent!~\"immich-server/.*\",user_agent!=\"\"}[24h])) or vector(0))",
+              "legendFormat": "raw other",
+              "refId": "C",
+              "interval": "1h",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "sum(sum_over_time(version:requests_other:count5m[24h]))",
+              "legendFormat": "rule other",
+              "refId": "D",
+              "interval": "30m",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "sum(count_over_time(version_handle_request_invocation[24h]))",
+              "legendFormat": "raw total",
+              "refId": "E",
+              "interval": "1h",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+              },
+              "expr": "sum(sum_over_time(version:requests:count5m[24h]))",
+              "legendFormat": "rule total",
+              "refId": "F",
+              "interval": "30m",
+              "range": true
+            }
+          ],
+          "title": "Request sums \u2014 raw vs rule",
+          "type": "timeseries"
+        }
+      ]
     }
   ],
   "refresh": "",

--- a/deployment/modules/cloudflare/workers/version/dashboards/version-worker-server-analytics.json
+++ b/deployment/modules/cloudflare/workers/version/dashboards/version-worker-server-analytics.json
@@ -1,0 +1,1043 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "panels": [],
+      "title": "Immich Servers",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "maxDataPoints": 300,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h])))",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Unique Servers (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "description": "Uses a 3h join window on version_latest_version_count: for up to 3h after a release, both the old and new version count as latest, inflating this stat.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 4,
+      "maxDataPoints": 300,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "expr": "count(count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h])) and on(user_agent) last_over_time(version_latest_version_count[3h])) / count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h])))",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Servers Up-to-date (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 9,
+      "maxDataPoints": 300,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(count(count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h]))) by (user_agent), \"version\", \"$1\", \"user_agent\", \"immich-server/(.*)\")",
+          "legendFormat": "{{version}}",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Version Distribution (24h)",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 8,
+      "maxDataPoints": 150,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "editorMode": "code",
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[2h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[2h])))",
+          "legendFormat": "unique servers (2h)",
+          "range": true,
+          "refId": "A",
+          "interval": "5m"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h])))",
+          "legendFormat": "unique servers (24h)",
+          "refId": "B",
+          "interval": "30m"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d])))",
+          "legendFormat": "unique servers (30d)",
+          "refId": "C",
+          "interval": "1h"
+        }
+      ],
+      "title": "Unique Servers Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "percent"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 10,
+      "maxDataPoints": 150,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(count(count by (client_ip, user_agent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[2h]))) by (user_agent), \"version\", \"$1\", \"user_agent\", \"immich-server/(.*)\")",
+          "legendFormat": "{{version}}",
+          "range": true,
+          "refId": "A",
+          "interval": "5m"
+        }
+      ],
+      "title": "Version Adoption Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "description": "New = client_ip not seen in the prior 30d. Subject to IP churn (CGNAT, IPv6 privacy rotation), and the prior-30d window is bounded by metrics retention.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 50,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 11,
+      "maxDataPoints": 300,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[5m]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[5m])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 5m) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 5m)))",
+          "legendFormat": "new servers",
+          "refId": "A",
+          "interval": "5m"
+        }
+      ],
+      "title": "New Servers (not seen in last 30d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "description": "Join semantics as panel 'Servers Up-to-date': 3h latest-version window inflates counts for up to 3h after a release. Only /version requests count toward activity here (not /changelog).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "upgrades (seen before)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "new installs"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 33,
+      "maxDataPoints": 150,
+      "targets": [
+        {
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1h]) and on(user_agent) last_over_time(version_latest_version_count[3h])) and count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h)))",
+          "legendFormat": "upgrades (seen before)",
+          "refId": "A",
+          "interval": "5m"
+        },
+        {
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1h]) and on(user_agent) last_over_time(version_latest_version_count[3h])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h)))",
+          "legendFormat": "new installs",
+          "refId": "B",
+          "interval": "5m"
+        }
+      ],
+      "title": "Latest Version: Upgrades vs New Installs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "description": "New = client_ip not seen in the prior 30d. Subject to IP churn (CGNAT, IPv6 privacy rotation), and the prior-30d window is bounded by metrics retention.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          },
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 34,
+      "maxDataPoints": 150,
+      "targets": [
+        {
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[1h])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1h)))",
+          "legendFormat": "new servers / 1h",
+          "refId": "A",
+          "interval": "5m"
+        },
+        {
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[1d]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[1d])) unless count by (client_ip) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1d) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[30d] offset 1d)))",
+          "legendFormat": "new servers / day",
+          "refId": "B",
+          "interval": "5m",
+          "hide": true
+        }
+      ],
+      "title": "New Server Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 37
+      },
+      "id": 12,
+      "maxDataPoints": 300,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count(count by (client_ip, continent) (count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h]) or count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h]))) by (continent)",
+          "legendFormat": "{{continent}}",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Servers by Continent (24h)",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Immich servers"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Other"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 37
+      },
+      "id": 13,
+      "maxDataPoints": 300,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "(sum(count_over_time(version_version_request_invocation{user_agent=~\"immich-server/.*\"}[24h])) or vector(0)) + (sum(count_over_time(version_changelog_request_invocation{user_agent=~\"immich-server/.*\"}[24h])) or vector(0))",
+          "legendFormat": "Immich servers",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        },
+        {
+          "expr": "(sum(count_over_time(version_version_request_invocation{user_agent!~\"immich-server/.*\",user_agent!=\"\"}[24h])) or vector(0)) + (sum(count_over_time(version_changelog_request_invocation{user_agent!~\"immich-server/.*\",user_agent!=\"\"}[24h])) or vector(0))",
+          "legendFormat": "Other",
+          "refId": "B",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Traffic Source (24h)",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-blues"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 37
+      },
+      "id": 14,
+      "maxDataPoints": 300,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "expr": "topk(15, sum(count_over_time(version_handle_request_invocation{colo!=\"\"}[24h])) by (colo))",
+          "legendFormat": "{{colo}}",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Top Cloudflare Edge Locations (24h)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "36979063-5384-4eb9-8679-565a727cbc13"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IPv4"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "IPv6"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 37
+      },
+      "id": 32,
+      "maxDataPoints": 300,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{client_ip!~\".*:.*\",client_ip!=\"\"}[24h]) or count_over_time(version_changelog_request_invocation{client_ip!~\".*:.*\",client_ip!=\"\"}[24h])))",
+          "legendFormat": "IPv4",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        },
+        {
+          "expr": "count(count by (client_ip) (count_over_time(version_version_request_invocation{client_ip=~\".*:.*\"}[24h]) or count_over_time(version_changelog_request_invocation{client_ip=~\".*:.*\"}[24h])))",
+          "legendFormat": "IPv6",
+          "refId": "B",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "IPv4 vs IPv6 (24h)",
+      "type": "piechart"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "cloudflare-workers",
+    "version"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5m",
+      "15m",
+      "30m",
+      "1h"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Version Worker Server Analytics",
+  "uid": "version-worker-server-analytics",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
- overview keeps worker performance, d1, data pipeline, and http panels
  at 1m refresh
- new server-analytics dashboard holds the client_ip-heavy panels with
  manual refresh only; coarser steps on the sliding 24h/30d targets
- fix cdn miss panel selector ({cache="miss"} never matched anything)
- document p95 semantics and latest-version join caveats in panel
  descriptions